### PR TITLE
Grove Mma7660のドライバ追加の修正

### DIFF
--- a/packages/mma7660/mma7660.js
+++ b/packages/mma7660/mma7660.js
@@ -31,7 +31,7 @@ class MMA7660 {
 
     const XYZresult = await this.i2cSlave.readBytes(3);
 
-    const int8ArrayMapped = new Int8Array(Array.from(XYZresult, value => {
+    const signedValueArray = Array.from(XYZresult, value => {
         // Perform noise reduction with bit masks
         value = value & 0x3F;
         // Converting 6-bit output results to signed values
@@ -39,12 +39,12 @@ class MMA7660 {
             value = value - 64;
         }
         return value;
-    }));
+    });
 
     const XYZdata = {
-      "X" : int8ArrayMapped[0],
-      "Y" : int8ArrayMapped[1],
-      "Z" : int8ArrayMapped[2],
+      "X" : signedValueArray[0],
+      "Y" : signedValueArray[1],
+      "Z" : signedValueArray[2],
     };
 
     return XYZdata;


### PR DESCRIPTION
プルリクエスト時に指摘をいただいた部分について修正を行なった。

[こちら](https://github.com/KDDI-Technology/chirimen-drivers/pull/6#issuecomment-3112294880)のコメント後に下記を追記
プルリクエストの指摘を受けて下記の修正を実施
- 注釈コメントの誤りを修正
- 関数名直後の不足していた半角スペースを追加
- ビットシフト処理を行っている箇所に実装意図のコメントを追加
- マジックナンバーになっていた箇所に名前をつけて定数を定義
- 不足していたセミコロンを追加
- 加速度情報が符号付き８ビット整数に正しく変換できていなかったため修正