### PR TITLE
feat: add as7341 driver

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -85,6 +85,10 @@
       "resolved": "packages/as5600",
       "link": true
     },
+    "node_modules/@chirimen/as7341": {
+      "resolved": "packages/as7341",
+      "link": true
+    },
     "node_modules/@chirimen/bh1750": {
       "resolved": "packages/bh1750",
       "link": true
@@ -7811,6 +7815,14 @@
     "packages/as5600": {
       "name": "@chirimen/as5600",
       "version": "2.0.0",
+      "license": "MIT",
+      "peerDependencies": {
+        "node-web-i2c": "^1.1.51"
+      }
+    },
+    "packages/as7341": {
+      "name": "@chirimen/as7341",
+      "version": "1.0.0",
       "license": "MIT",
       "peerDependencies": {
         "node-web-i2c": "^1.1.51"

--- a/packages/as7341/README.md
+++ b/packages/as7341/README.md
@@ -95,7 +95,7 @@ SMUXの切り替えを伴う2回の測定（F1〜F4系→F5〜F8系）を内部�
 
 ## データシート
 
-データシート要確認（ams-OSRAM AS7341 のデータシートを参照してください）
+- [AS7341 Datasheet (ams-OSRAM)](https://www.mouser.jp/datasheet/3/5912/1/AS7341_DS000504_3_00.pdf)
 
 ## 参考
 

--- a/packages/as7341/README.md
+++ b/packages/as7341/README.md
@@ -1,0 +1,102 @@
+# @chirimen/as7341
+
+CHIRIMEN driver for AS7341 (11-channel spectral color sensor)
+
+ams-OSRAM製の11チャンネル分光カラーセンサー AS7341 用のCHIRIMENドライバです。
+可視光域をカバーする8つの分光チャンネル（F1〜F8: 415nm〜680nm）に加え、
+Clear（全可視光）とNIR（近赤外）の測定に対応します。
+光の色成分・スペクトル分析、色識別、光源の種類判定などの用途に利用できます。
+測定時間（ATIME/ASTEP）とゲイン（0.5倍〜512倍）を設定可能です。
+
+## 主な仕様
+
+| 項目             | 内容                               |
+| ---------------- | ---------------------------------- |
+| 型番             | AS7341                             |
+| インターフェース | I2C                                |
+| I2Cアドレス      | 0x39                               |
+| 測定チャンネル   | F1〜F8（415nm〜680nm）、Clear、NIR |
+
+## Installation
+
+```sh
+npm install @chirimen/as7341
+```
+
+## Usage
+
+```javascript
+import { requestI2CAccess } from "chirimen";
+import AS7341 from "@chirimen/as7341";
+
+const i2cAccess = await requestI2CAccess();
+const i2cPort = i2cAccess.ports.get(1);
+const as7341 = new AS7341(i2cPort, 0x39);
+
+await as7341.init();
+
+setInterval(async () => {
+  const data = await as7341.read();
+  // { f1, f2, f3, f4, f5, f6, f7, f8, clear, nir }
+  console.log(data);
+}, 1000);
+```
+
+## API
+
+### `new AS7341(i2cPort, slaveAddress)`
+
+ドライバのインスタンスを生成します。
+
+- `i2cPort`: `requestI2CAccess()` で取得したI2Cポート
+- `slaveAddress`: I2Cアドレス（`0x39`）
+
+### `async init()`
+
+センサーを初期化します。チップIDの確認・電源ONの後、測定条件のデフォルト値
+（ATIME=100、ASTEP=999、ゲイン=256倍）を設定します。
+初期化に失敗した場合は `null` を返します。
+
+### `async setATIME(value)`
+
+積分時間パラメータ ATIME を設定します（`0`〜`255`）。
+範囲外の値を渡した場合は `null` を返します。
+
+### `async setASTEP(value)`
+
+積分ステップ時間パラメータ ASTEP を設定します（`0`〜`65534`）。
+範囲外の値を渡した場合は `null` を返します。
+
+### `async setGain(gain)`
+
+ADCのゲイン（倍率）を設定します。指定できる値は
+`0.5, 1, 2, 4, 8, 16, 32, 64, 128, 256, 512` のいずれかです。
+無効な値を渡した場合は `null` を返します。
+
+### `async read()`
+
+全チャンネルの測定を行い、結果をオブジェクトで返します。
+SMUXの切り替えを伴う2回の測定（F1〜F4系→F5〜F8系）を内部で実行します。
+
+```javascript
+{
+  f1: number,    // 415nm
+  f2: number,    // 445nm
+  f3: number,    // 480nm
+  f4: number,    // 515nm
+  f5: number,    // 555nm
+  f6: number,    // 590nm
+  f7: number,    // 630nm
+  f8: number,    // 680nm
+  clear: number, // 全可視光
+  nir: number    // 近赤外
+}
+```
+
+## データシート
+
+データシート要確認（ams-OSRAM AS7341 のデータシートを参照してください）
+
+## 参考
+
+- [Adafruit_AS7341](https://github.com/adafruit/Adafruit_AS7341)（参考にした実装元）

--- a/packages/as7341/index.js
+++ b/packages/as7341/index.js
@@ -1,0 +1,184 @@
+// @ts-check
+// AS7341 driver for CHIRIMEN
+// Based from https://github.com/adafruit/Adafruit_AS7341
+// Programmed by Rion Kawashima
+
+const AS7341_WHOAMI = 0x92;
+const AS7341_CHIP_ID = 0x09;
+const AS7341_ENABLE = 0x80;
+const AS7341_ATIME = 0x81;
+const AS7341_ASTEP_L = 0xca;
+const AS7341_ASTEP_H = 0xcb;
+const AS7341_CFG1 = 0xaa; // ゲイン設定
+// ゲイン倍率とレジスタ値(0〜10)の対応表
+const GAIN_TABLE = [0.5, 1, 2, 4, 8, 16, 32, 64, 128, 256, 512];
+const AS7341_CFG6 = 0xaf; // SMUXコマンドレジスタ
+const AS7341_STATUS2 = 0xa3; // 測定完了フラグ(AVALID)
+const AS7341_CH0_DATA_L = 0x95; // 測定データの先頭番地
+const SMUX_CMD_WRITE = 0x10; // SMUX書き込みモード(bit4:3 = 10b)
+
+// SMUX結線パターン（Adafruit setup_F1F4_Clear_NIR() より）
+// ADC0=F1, ADC1=F2, ADC2=F3, ADC3=F4, ADC4=Clear, ADC5=NIR
+const SMUX_F1F4_CLEAR_NIR = [
+  0x30, 0x01, 0x00, 0x00, 0x00, 0x42, 0x00, 0x00, 0x50, 0x00, 0x00, 0x00, 0x20,
+  0x04, 0x00, 0x30, 0x01, 0x50, 0x00, 0x06,
+];
+
+// SMUX結線パターン（Adafruit setup_F5F8_Clear_NIR() より）
+// ADC0=F5, ADC1=F6, ADC2=F7, ADC3=F8, ADC4=Clear, ADC5=NIR
+const SMUX_F5F8_CLEAR_NIR = [
+  0x00, 0x00, 0x00, 0x40, 0x02, 0x00, 0x10, 0x03, 0x50, 0x10, 0x03, 0x00, 0x00,
+  0x00, 0x24, 0x00, 0x00, 0x50, 0x00, 0x06,
+];
+
+class AS7341 {
+  constructor(i2cPort, slaveAddress) {
+    this.i2cPort = i2cPort;
+    this.i2cSlave = null;
+    this.slaveAddress = slaveAddress;
+  }
+  async init() {
+    try {
+      this.i2cSlave = await this.i2cPort.open(this.slaveAddress);
+
+      // ① ID確認：正しいチップと会話できているかチェック
+      const id = await this.i2cSlave.read8(AS7341_WHOAMI);
+      if (id >> 2 !== AS7341_CHIP_ID) {
+        throw new Error("AS7341 not found. id=0x" + id.toString(16));
+      }
+
+      // ② 電源ON：ENABLEレジスタのbit0(PON)を立てる
+      let enable = await this.i2cSlave.read8(AS7341_ENABLE);
+      enable |= 0x01;
+      await this.i2cSlave.write8(AS7341_ENABLE, enable);
+      await this.wait(10);
+
+      // ③ 測定条件のデフォルト設定
+      await this.setATIME(100);
+      await this.setASTEP(999);
+      await this.setGain(256);
+    } catch (e) {
+      console.error("AS7341.init() error : " + e);
+      return null;
+    }
+    return this;
+  }
+  async wait(ms) {
+    return new Promise((resolve) => {
+      setTimeout(() => {
+        resolve();
+      }, ms);
+    });
+  }
+  async setATIME(value) {
+    if (this.i2cSlave == null) {
+      throw new Error("i2cSlave is not open yet.");
+    }
+    if (value < 0 || value > 255) {
+      console.error("AS7341.setATIME() value must be 0-255!");
+      return null;
+    }
+    await this.i2cSlave.write8(AS7341_ATIME, value);
+    return value;
+  }
+  async setASTEP(value) {
+    if (this.i2cSlave == null) {
+      throw new Error("i2cSlave is not open yet.");
+    }
+    if (value < 0 || value > 65534) {
+      console.error("AS7341.setASTEP() value must be 0-65534!");
+      return null;
+    }
+    await this.i2cSlave.write8(AS7341_ASTEP_L, value & 0xff);
+    await this.i2cSlave.write8(AS7341_ASTEP_H, (value >> 8) & 0xff);
+    return value;
+  }
+  async setGain(gain) {
+    if (this.i2cSlave == null) {
+      throw new Error("i2cSlave is not open yet.");
+    }
+    const idx = GAIN_TABLE.indexOf(gain);
+    if (idx < 0) {
+      console.error("AS7341.setGain() invalid gain! (0.5, 1, 2, 4, ... 512)");
+      return null;
+    }
+    await this.i2cSlave.write8(AS7341_CFG1, idx);
+    return gain;
+  }
+  async #setSmux(config) {
+    // 測定を一旦停止（ENABLE bit1 = SP_EN を0に）
+    let enable = await this.i2cSlave.read8(AS7341_ENABLE);
+    enable &= ~0x02;
+    await this.i2cSlave.write8(AS7341_ENABLE, enable);
+
+    // 「これからSMUX設定を書くぞ」とチップに宣言
+    await this.i2cSlave.write8(AS7341_CFG6, SMUX_CMD_WRITE);
+
+    // 結線パターン20バイトを0x00〜0x13に書く
+    for (let i = 0; i < config.length; i++) {
+      await this.i2cSlave.write8(i, config[i]);
+    }
+
+    // ENABLE bit4(SMUXEN)=1 で反映開始。チップが処理を終えるとbit4が勝手に0に戻る（最大1秒待つ）
+    enable = await this.i2cSlave.read8(AS7341_ENABLE);
+    enable |= 0x10;
+    await this.i2cSlave.write8(AS7341_ENABLE, enable);
+    for (let i = 0; i < 100; i++) {
+      if (!((await this.i2cSlave.read8(AS7341_ENABLE)) & 0x10)) {
+        return;
+      }
+      await this.wait(10);
+    }
+    console.error("AS7341.#setSmux() timeout!");
+  }
+  async #measure() {
+    // 測定開始（ENABLE bit1 = SP_EN を1に）
+    let enable = await this.i2cSlave.read8(AS7341_ENABLE);
+    enable |= 0x02;
+    await this.i2cSlave.write8(AS7341_ENABLE, enable);
+
+    // STATUS2のbit6(AVALID)が立つ＝測定完了まで待つ（最大3秒）
+    for (let i = 0; i < 300; i++) {
+      if ((await this.i2cSlave.read8(AS7341_STATUS2)) & 0x40) {
+        return;
+      }
+      await this.wait(10);
+    }
+    console.error("AS7341.#measure() timeout!");
+  }
+  async #readChannels() {
+    await this.i2cSlave.writeByte(AS7341_CH0_DATA_L);
+    const raw = await this.i2cSlave.readBytes(12);
+    const ch = [];
+    for (let i = 0; i < 6; i++) {
+      ch.push(raw[i * 2] | (raw[i * 2 + 1] << 8));
+    }
+    return ch;
+  }
+  async read() {
+    if (this.i2cSlave == null) {
+      throw new Error("i2cSlave is not open yet.");
+    }
+    await this.#setSmux(SMUX_F1F4_CLEAR_NIR);
+    await this.#measure();
+    const low = await this.#readChannels(); // [F1, F2, F3, F4, Clear, NIR]
+
+    await this.#setSmux(SMUX_F5F8_CLEAR_NIR);
+    await this.#measure();
+    const high = await this.#readChannels(); // [F5, F6, F7, F8, Clear, NIR]
+
+    return {
+      f1: low[0],
+      f2: low[1],
+      f3: low[2],
+      f4: low[3],
+      f5: high[0],
+      f6: high[1],
+      f7: high[2],
+      f8: high[3],
+      clear: high[4],
+      nir: high[5],
+    };
+  }
+}
+export default AS7341;

--- a/packages/as7341/package.json
+++ b/packages/as7341/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@chirimen/as7341",
+  "description": "CHIRIMEN driver for AS7341 sensor",
+  "version": "1.0.0",
+  "license": "MIT",
+  "type": "module",
+  "exports": "./index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/chirimen-oh/chirimen-drivers.git",
+    "directory": "packages/as7341"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "peerDependencies": {
+    "node-web-i2c": "^1.1.51"
+  }
+}


### PR DESCRIPTION
## 概要
ams-OSRAM製 11チャンネル分光カラーセンサー AS7341 のドライバを追加します。

- 測定チャンネル: F1〜F8（415〜680nm）+ Clear + NIR
- インターフェース: I2C（アドレス 0x39）
- 参考実装: https://github.com/adafruit/Adafruit_AS7341

## 動作確認
- Raspberry Pi Zero + AS7341 実機にて、init() → read() の測定値取得を確認済み

## 追加ファイル
- `packages/as7341/index.js` / `package.json` / `README.md`
- `package-lock.json`（npm installによる自動更新）