### PR TITLE
fix: コンストラクタのslaveAddressにデフォルト値0x39を追加

### DIFF
--- a/packages/as7341/index.js
+++ b/packages/as7341/index.js
@@ -32,7 +32,7 @@ const SMUX_F5F8_CLEAR_NIR = [
 ];
 
 class AS7341 {
-  constructor(i2cPort, slaveAddress) {
+  constructor(i2cPort, slaveAddress = 0x39) {
     this.i2cPort = i2cPort;
     this.i2cSlave = null;
     this.slaveAddress = slaveAddress;


### PR DESCRIPTION
本家PR chirimen-oh/chirimen-drivers#475 の追加指摘への対応です。前回READMEのみ更新し、コンストラクタ本体への追加が漏れていたため修正しました。