### PR TITLE
feat: add STHS34PF80 driver

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -253,6 +253,10 @@
       "resolved": "packages/sht40",
       "link": true
     },
+    "node_modules/@chirimen/sths34pf80": {
+      "resolved": "packages/sths34pf80",
+      "link": true
+    },
     "node_modules/@chirimen/tca9548a": {
       "resolved": "packages/tca9548a",
       "link": true
@@ -7571,6 +7575,14 @@
     "packages/sht40": {
       "name": "@chirimen/sht40",
       "version": "2.0.0",
+      "license": "MIT",
+      "peerDependencies": {
+        "node-web-i2c": "^1.1.51"
+      }
+    },
+    "packages/sths34pf80": {
+      "name": "@chirimen/sths34pf80",
+      "version": "1.0.0",
       "license": "MIT",
       "peerDependencies": {
         "node-web-i2c": "^1.1.51"

--- a/packages/sths34pf80/README.md
+++ b/packages/sths34pf80/README.md
@@ -32,7 +32,12 @@ const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 const i2cAccess = await requestI2CAccess();
 const sths34pf80 = new STHS34PF80(i2cAccess.ports.get(1));
 
-await sths34pf80.init();
+try {
+  await sths34pf80.init();
+} catch (e) {
+  console.error("センサーの初期化に失敗しました:", e);
+  throw e;
+}
 
 while (true) {
   const data = await sths34pf80.read();
@@ -53,7 +58,7 @@ while (true) {
 ### `async init()`
 
 センサーを初期化します。WHO_AM_Iレジスタの値を確認したうえで、BDU（Block Data Update）を有効化し、出力データレート（ODR）を4Hzに設定します。
-初期化に失敗した場合は `null` を返します。
+初期化に失敗した場合は例外（`Error`）をthrowします。呼び出し側で`try/catch`してください。
 
 ### `async readWhoAmI()`
 

--- a/packages/sths34pf80/README.md
+++ b/packages/sths34pf80/README.md
@@ -1,38 +1,103 @@
-# STHS34PF80
+# @chirimen/sths34pf80
 
-STHS34PF80 is a high-precision infrared temperature sensor from STMicroelectronics.
+CHIRIMEN driver for STHS34PF80 (Infrared presence and motion sensor with temperature sensing)
 
-This package provides a WebI2C driver for CHIRIMEN.
+STMicroelectronics製のIRセンサー STHS34PF80 用のCHIRIMENドライバです。
+対象物からの赤外線強度（TOBJECT）と周辺温度（TAMBIENT）を取得できます。
+STHS34PF80は人感・動体検知（presence/motion detection）を主機能とするセンサーですが、本ドライバは温度読み取り専用です（詳細は下記「対応範囲について」を参照）。
+
+## 主な仕様
+
+| 項目             | 内容                                                                                 |
+| ---------------- | ------------------------------------------------------------------------------------ |
+| 型番             | STHS34PF80                                                                           |
+| インターフェース | I2C                                                                                  |
+| I2Cアドレス      | `0x5A`                                                                               |
+| 測定項目         | 周辺温度(`ambientTemperature`)、対象物からの赤外線強度(`objectTemperatureRaw`、生値) |
+| 出力データレート | 4Hz（既定。本ドライバでは固定）                                                      |
+
+## Installation
+
+```sh
+npm install @chirimen/sths34pf80
+```
 
 ## Usage
 
 ```js
 import { requestI2CAccess } from "node-web-i2c";
 import STHS34PF80 from "@chirimen/sths34pf80";
-
-const I2CADDR_STHS34PF80 = 0x5a;
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
 const i2cAccess = await requestI2CAccess();
-const i2cPort = i2cAccess.ports.get(1);
+const sths34pf80 = new STHS34PF80(i2cAccess.ports.get(1));
 
-const sensor = new STHS34PF80(
-  i2cPort,
-  I2CADDR_STHS34PF80
-);
+await sths34pf80.init();
 
-await sensor.init();
-
-const whoAmI = await sensor.readWhoAmI();
-console.log("WHO_AM_I:", "0x" + whoAmI.toString(16));
-
-const data = await sensor.read();
-console.dir(data);
+while (true) {
+  const data = await sths34pf80.read();
+  console.dir(data);
+  await sleep(250);
+}
 ```
 
-## I2C Address
+## API
 
-The default I2C address is `0x5A`.
+### `new STHS34PF80(i2cPort, slaveAddress = 0x5A)`
 
-## Reference
+ドライバのインスタンスを生成します。
+
+- `i2cPort`: `requestI2CAccess()` で取得したI2Cポート
+- `slaveAddress`: I2Cアドレス（省略可。デフォルト値: `0x5A`）
+
+### `async init()`
+
+センサーを初期化します。WHO_AM_Iレジスタの値を確認したうえで、BDU（Block Data Update）を有効化し、出力データレート（ODR）を4Hzに設定します。
+初期化に失敗した場合は `null` を返します。
+
+### `async readWhoAmI()`
+
+WHO_AM_Iレジスタ（デバイスID、既定値: `0xD3`）の値を取得します。
+
+### `async readStatus()`
+
+STATUSレジスタの値を取得します。bit2がDRDY（新しい測定データの準備完了フラグ）です。
+
+### `async readFunctionStatus()`
+
+FUNC_STATUSレジスタの値を取得します。bit0〜2はそれぞれ周辺温度シェイク・動体検知・人感検知のフラグに対応しますが、本ドライバではこれらの検知アルゴリズムを設定していないため、有効な値は返りません（詳細は下記「対応範囲について」を参照）。
+
+### `async readObjectTemperatureRaw()`
+
+対象物からの赤外線強度の生値（符号付き16bit）を取得します。DRDYが立つまで内部で待機します。
+
+### `async readAmbientTemperatureRaw()`
+
+周辺温度の生値（符号付き16bit、単位: 1/100°C）を取得します。DRDYが立つまで内部で待機します。
+
+### `async read()`
+
+対象物の赤外線強度・周辺温度をまとめて測定し、結果をオブジェクトで返します。
+
+```js
+{
+  objectTemperatureRaw: number,   // 対象物からの赤外線強度の生値（未変換）
+  ambientTemperatureRaw: number,  // 周辺温度の生値（1/100°C単位）
+  ambientTemperature: number      // 周辺温度（°C）
+}
+```
+
+`objectTemperatureRaw`は生値のまま返します。STHS34PF80のTOBJECTはセンサー感度2000 LSB/°Cの生IR強度であり、絶対温度に変換するには対象物の放射率などを考慮した補正アルゴリズムが必要なためです（詳細は[AN5867](https://www.st.com/resource/en/application_note/an5867-sths34pf80-lowpower-highsensitivity-infrared-ir-sensor-for-presence-and-motion-detection-stmicroelectronics.pdf)を参照）。`ambientTemperature`とは異なり単位付きの温度に変換されていない点に注意してください。
+
+## 対応範囲について
+
+STHS34PF80は温度センサーとしてだけでなく、TPRESENCE/TMOTIONレジスタやアルゴリズム設定（CTRL2/CTRL3、しきい値レジスタ等）による人感・動体検知（presence/motion detection）を主機能とするIRセンサーです。
+本ドライバはTOBJECT/TAMBIENTの温度読み取りのみに対応しており、人感・動体検知機能には対応していません。これらの機能が必要な場合は、[AN5867](https://www.st.com/resource/en/application_note/an5867-sths34pf80-lowpower-highsensitivity-infrared-ir-sensor-for-presence-and-motion-detection-stmicroelectronics.pdf)を参考に別途アルゴリズム設定を実装してください。
+
+## データシート
 
 - [STHS34PF80 Datasheet](https://www.st.com/resource/en/datasheet/sths34pf80.pdf)
+
+## 参考
+
+- [AN5867: STHS34PF80 low-power, high-sensitivity IR sensor for presence and motion detection](https://www.st.com/resource/en/application_note/an5867-sths34pf80-lowpower-highsensitivity-infrared-ir-sensor-for-presence-and-motion-detection-stmicroelectronics.pdf)

--- a/packages/sths34pf80/README.md
+++ b/packages/sths34pf80/README.md
@@ -1,0 +1,38 @@
+# STHS34PF80
+
+STHS34PF80 is a high-precision infrared temperature sensor from STMicroelectronics.
+
+This package provides a WebI2C driver for CHIRIMEN.
+
+## Usage
+
+```js
+import { requestI2CAccess } from "node-web-i2c";
+import STHS34PF80 from "@chirimen/sths34pf80";
+
+const I2CADDR_STHS34PF80 = 0x5a;
+
+const i2cAccess = await requestI2CAccess();
+const i2cPort = i2cAccess.ports.get(1);
+
+const sensor = new STHS34PF80(
+  i2cPort,
+  I2CADDR_STHS34PF80
+);
+
+await sensor.init();
+
+const whoAmI = await sensor.readWhoAmI();
+console.log("WHO_AM_I:", "0x" + whoAmI.toString(16));
+
+const data = await sensor.read();
+console.dir(data);
+```
+
+## I2C Address
+
+The default I2C address is `0x5A`.
+
+## Reference
+
+- [STHS34PF80 Datasheet](https://www.st.com/resource/en/datasheet/sths34pf80.pdf)

--- a/packages/sths34pf80/README.md
+++ b/packages/sths34pf80/README.md
@@ -8,13 +8,13 @@ STHS34PF80は人感・動体検知（presence/motion detection）を主機能と
 
 ## 主な仕様
 
-| 項目             | 内容                                                                                 |
-| ---------------- | ------------------------------------------------------------------------------------ |
-| 型番             | STHS34PF80                                                                           |
-| インターフェース | I2C                                                                                  |
-| I2Cアドレス      | `0x5A`                                                                               |
-| 測定項目         | 周辺温度(`ambientTemperature`)、対象物からの赤外線強度(`objectTemperatureRaw`、生値) |
-| 出力データレート | 4Hz（既定。本ドライバでは固定）                                                      |
+| 項目             | 内容                                                                          |
+| ---------------- | ----------------------------------------------------------------------------- |
+| 型番             | STHS34PF80                                                                    |
+| インターフェース | I2C                                                                           |
+| I2Cアドレス      | `0x5A`                                                                        |
+| 測定項目         | 周辺温度(`ambientTemperature`)、対象物の温度(`objectTemperature`、簡易換算値) |
+| 出力データレート | 4Hz（既定。本ドライバでは固定）                                               |
 
 ## Installation
 
@@ -82,12 +82,13 @@ FUNC_STATUSレジスタの値を取得します。bit0〜2はそれぞれ周辺�
 ```js
 {
   objectTemperatureRaw: number,   // 対象物からの赤外線強度の生値（未変換）
+  objectTemperature: number,      // 対象物の温度（°C、簡易換算値）
   ambientTemperatureRaw: number,  // 周辺温度の生値（1/100°C単位）
   ambientTemperature: number      // 周辺温度（°C）
 }
 ```
 
-`objectTemperatureRaw`は生値のまま返します。STHS34PF80のTOBJECTはセンサー感度2000 LSB/°Cの生IR強度であり、絶対温度に変換するには対象物の放射率などを考慮した補正アルゴリズムが必要なためです（詳細は[AN5867](https://www.st.com/resource/en/application_note/an5867-sths34pf80-lowpower-highsensitivity-infrared-ir-sensor-for-presence-and-motion-detection-stmicroelectronics.pdf)を参照）。`ambientTemperature`とは異なり単位付きの温度に変換されていない点に注意してください。
+`objectTemperature`はTOBJECTの感度（2000 LSB/°C）による簡易換算値です。放射率や対象物との距離による補正は行っていないため、厳密な絶対温度ではなく目安として扱ってください。より高精度な補正が必要な場合は、[AN5867](https://www.st.com/resource/en/application_note/an5867-sths34pf80-lowpower-highsensitivity-infrared-ir-sensor-for-presence-and-motion-detection-stmicroelectronics.pdf)記載の補正アルゴリズム（TOBJ_COMPレジスタ等）を参照してください。
 
 ## 対応範囲について
 

--- a/packages/sths34pf80/index.js
+++ b/packages/sths34pf80/index.js
@@ -1,4 +1,8 @@
-// STHS34PF80実機動作確認
+// @ts-check
+
+// STHS34PF80 driver for CHIRIMEN
+
+// https://www.st.com/resource/en/datasheet/sths34pf80.pdf
 const ADDRESS = 0x5A;
 
 // Registers

--- a/packages/sths34pf80/index.js
+++ b/packages/sths34pf80/index.js
@@ -1,12 +1,13 @@
 // @ts-check
 
 // STHS34PF80 driver for CHIRIMEN
-
 // https://www.st.com/resource/en/datasheet/sths34pf80.pdf
-const ADDRESS = 0x5A;
+// Programmed by x-na-ogata
+
+const ADDRESS = 0x5a;
 
 // Registers
-const WHO_AM_I = 0x0F;
+const WHO_AM_I = 0x0f;
 const CTRL1 = 0x20;
 const STATUS = 0x23;
 const FUNC_STATUS = 0x25;
@@ -14,6 +15,9 @@ const TOBJECT_L = 0x26;
 const TOBJECT_H = 0x27;
 const TAMBIENT_L = 0x28;
 const TAMBIENT_H = 0x29;
+
+const STHS34PF80_ID = 0xd3; // WHO_AM_I の既定値
+const STATUS_DRDY = 0x04; // STATUS(0x23) bit2: TOBJECT/TAMBIENTの新しいデータが準備できたことを示すフラグ
 
 class STHS34PF80 {
   constructor(i2cPort, slaveAddress = ADDRESS) {
@@ -23,60 +27,106 @@ class STHS34PF80 {
   }
 
   async init() {
-    this.i2cSlave = await this.i2cPort.open(this.slaveAddress);
+    try {
+      this.i2cSlave = await this.i2cPort.open(this.slaveAddress);
 
-    // BDU = 1, ODR = 4 Hz
-    await this.i2cSlave.write8(CTRL1, 0x15);
+      const id = await this.i2cSlave.read8(WHO_AM_I);
+      if (id !== STHS34PF80_ID) {
+        throw new Error("STHS34PF80 not found. id=0x" + id.toString(16));
+      }
+
+      // BDU = 1, ODR = 4 Hz
+      await this.i2cSlave.write8(CTRL1, 0x15);
+    } catch (e) {
+      console.error("STHS34PF80.init() error : " + e);
+      return null;
+    }
+    return this;
+  }
+
+  wait(ms) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
   }
 
   async readWhoAmI() {
+    if (this.i2cSlave == null) {
+      throw new Error("i2cSlave is not open yet.");
+    }
     return await this.i2cSlave.read8(WHO_AM_I);
   }
 
   async readStatus() {
+    if (this.i2cSlave == null) {
+      throw new Error("i2cSlave is not open yet.");
+    }
     return await this.i2cSlave.read8(STATUS);
   }
 
   async readFunctionStatus() {
+    if (this.i2cSlave == null) {
+      throw new Error("i2cSlave is not open yet.");
+    }
     return await this.i2cSlave.read8(FUNC_STATUS);
   }
 
-  async readObjectTemperatureRaw() {
-    const low = await this.i2cSlave.read8(TOBJECT_L);
-    const high = await this.i2cSlave.read8(TOBJECT_H);
+  // ODR周期(4Hzなら250ms)より速く連続でreadすると古いデータを読んでしまうため、
+  // STATUSのDRDYビットが立つまで待つ
+  async #waitForDataReady(timeoutMs = 500) {
+    const steps = Math.ceil(timeoutMs / 10);
+    for (let i = 0; i < steps; i++) {
+      const status = await this.i2cSlave.read8(STATUS);
+      if (status & STATUS_DRDY) {
+        return;
+      }
+      await this.wait(10);
+    }
+    throw new Error("STHS34PF80: measurement timeout");
+  }
 
-    let value = (high << 8) | low;
+  // TOBJECT_L(0x26)〜TAMBIENT_H(0x29)は連続したレジスタなので、
+  // read8を4回に分けず1回のバーストリードで取得する
+  async #readTemperatures() {
+    if (this.i2cSlave == null) {
+      throw new Error("i2cSlave is not open yet.");
+    }
+    await this.#waitForDataReady();
+    await this.i2cSlave.writeByte(TOBJECT_L);
+    const raw = await this.i2cSlave.readBytes(4);
 
+    let objectRaw = raw[0] | (raw[1] << 8);
     // Convert unsigned 16-bit to signed 16-bit
-    if (value & 0x8000) {
-      value -= 0x10000;
+    if (objectRaw & 0x8000) {
+      objectRaw -= 0x10000;
     }
 
-    return value;
+    let ambientRaw = raw[2] | (raw[3] << 8);
+    // Convert unsigned 16-bit to signed 16-bit
+    if (ambientRaw & 0x8000) {
+      ambientRaw -= 0x10000;
+    }
+
+    return { objectRaw, ambientRaw };
+  }
+
+  async readObjectTemperatureRaw() {
+    const { objectRaw } = await this.#readTemperatures();
+    return objectRaw;
   }
 
   async readAmbientTemperatureRaw() {
-    const low = await this.i2cSlave.read8(TAMBIENT_L);
-    const high = await this.i2cSlave.read8(TAMBIENT_H);
-
-    let value = (high << 8) | low;
-
-    // Convert unsigned 16-bit to signed 16-bit
-    if (value & 0x8000) {
-      value -= 0x10000;
-    }
-
-    return value;
+    const { ambientRaw } = await this.#readTemperatures();
+    return ambientRaw;
   }
 
   async read() {
-    const objectRaw = await this.readObjectTemperatureRaw();
-    const ambientRaw = await this.readAmbientTemperatureRaw();
+    const { objectRaw, ambientRaw } = await this.#readTemperatures();
 
     return {
+      // TOBJECTはセンサー感度2000 LSB/°Cの生IR強度で、絶対温度への変換には
+      // AN5867記載の補正アルゴリズムが必要なため、変換せず生値のまま返す
       objectTemperatureRaw: objectRaw,
       ambientTemperatureRaw: ambientRaw,
-      ambientTemperature: ambientRaw / 100
+      ambientTemperature: ambientRaw / 100,
     };
   }
 }

--- a/packages/sths34pf80/index.js
+++ b/packages/sths34pf80/index.js
@@ -18,6 +18,7 @@ const TAMBIENT_H = 0x29;
 
 const STHS34PF80_ID = 0xd3; // WHO_AM_I の既定値
 const STATUS_DRDY = 0x04; // STATUS(0x23) bit2: TOBJECT/TAMBIENTの新しいデータが準備できたことを示すフラグ
+const TOBJECT_SENSITIVITY = 2000; // TOBJECTの感度(2000 LSB/°C。データシート記載値)
 
 class STHS34PF80 {
   constructor(i2cPort, slaveAddress = ADDRESS) {
@@ -122,9 +123,11 @@ class STHS34PF80 {
     const { objectRaw, ambientRaw } = await this.#readTemperatures();
 
     return {
-      // TOBJECTはセンサー感度2000 LSB/°Cの生IR強度で、絶対温度への変換には
-      // AN5867記載の補正アルゴリズムが必要なため、変換せず生値のまま返す
       objectTemperatureRaw: objectRaw,
+      // TOBJECTの感度(2000 LSB/°C)による簡易換算値。放射率や距離による補正は
+      // 行っていないため、厳密な絶対温度ではなく目安として扱うこと。より高精度な
+      // 補正が必要な場合はAN5867記載のアルゴリズム(TOBJ_COMP等)を参照
+      objectTemperature: objectRaw / TOBJECT_SENSITIVITY,
       ambientTemperatureRaw: ambientRaw,
       ambientTemperature: ambientRaw / 100,
     };

--- a/packages/sths34pf80/index.js
+++ b/packages/sths34pf80/index.js
@@ -39,8 +39,9 @@ class STHS34PF80 {
       // BDU = 1, ODR = 4 Hz
       await this.i2cSlave.write8(CTRL1, 0x15);
     } catch (e) {
-      console.error("STHS34PF80.init() error : " + e);
-      return null;
+      // read*系と同じく、初期化失敗時もthrowして呼び出し元のtry/catchに委ねる
+      this.i2cSlave = null;
+      throw e;
     }
     return this;
   }
@@ -71,12 +72,15 @@ class STHS34PF80 {
   }
 
   // ODR周期(4Hzなら250ms)より速く連続でreadすると古いデータを読んでしまうため、
-  // STATUSのDRDYビットが立つまで待つ
+  // STATUSのDRDYビットが立つまで待つ。DRDYはSTATUSやTOBJECT/TAMBIENTを読んでも
+  // クリアされず、FUNC_STATUS(0x25)を読むことで初めてクリアされるため、
+  // 次回呼び出しのために明示的にFUNC_STATUSを読んでおく
   async #waitForDataReady(timeoutMs = 500) {
     const steps = Math.ceil(timeoutMs / 10);
     for (let i = 0; i < steps; i++) {
       const status = await this.i2cSlave.read8(STATUS);
       if (status & STATUS_DRDY) {
+        await this.i2cSlave.read8(FUNC_STATUS);
         return;
       }
       await this.wait(10);
@@ -109,11 +113,21 @@ class STHS34PF80 {
     return { objectRaw, ambientRaw };
   }
 
+  /**
+   * objectとambientを同一サンプルで揃えて取得したい場合はread()を使うこと。
+   * 本メソッド単体では、呼び出しのたびにDRDY待ちが発生するため、
+   * read()内でまとめて取得する場合とは異なるサンプルになり得る。
+   */
   async readObjectTemperatureRaw() {
     const { objectRaw } = await this.#readTemperatures();
     return objectRaw;
   }
 
+  /**
+   * objectとambientを同一サンプルで揃えて取得したい場合はread()を使うこと。
+   * 本メソッド単体では、呼び出しのたびにDRDY待ちが発生するため、
+   * read()内でまとめて取得する場合とは異なるサンプルになり得る。
+   */
   async readAmbientTemperatureRaw() {
     const { ambientRaw } = await this.#readTemperatures();
     return ambientRaw;

--- a/packages/sths34pf80/index.js
+++ b/packages/sths34pf80/index.js
@@ -1,0 +1,80 @@
+// STHS34PF80実機動作確認
+const ADDRESS = 0x5A;
+
+// Registers
+const WHO_AM_I = 0x0F;
+const CTRL1 = 0x20;
+const STATUS = 0x23;
+const FUNC_STATUS = 0x25;
+const TOBJECT_L = 0x26;
+const TOBJECT_H = 0x27;
+const TAMBIENT_L = 0x28;
+const TAMBIENT_H = 0x29;
+
+class STHS34PF80 {
+  constructor(i2cPort, slaveAddress = ADDRESS) {
+    this.i2cPort = i2cPort;
+    this.slaveAddress = slaveAddress;
+    this.i2cSlave = null;
+  }
+
+  async init() {
+    this.i2cSlave = await this.i2cPort.open(this.slaveAddress);
+
+    // BDU = 1, ODR = 4 Hz
+    await this.i2cSlave.write8(CTRL1, 0x15);
+  }
+
+  async readWhoAmI() {
+    return await this.i2cSlave.read8(WHO_AM_I);
+  }
+
+  async readStatus() {
+    return await this.i2cSlave.read8(STATUS);
+  }
+
+  async readFunctionStatus() {
+    return await this.i2cSlave.read8(FUNC_STATUS);
+  }
+
+  async readObjectTemperatureRaw() {
+    const low = await this.i2cSlave.read8(TOBJECT_L);
+    const high = await this.i2cSlave.read8(TOBJECT_H);
+
+    let value = (high << 8) | low;
+
+    // Convert unsigned 16-bit to signed 16-bit
+    if (value & 0x8000) {
+      value -= 0x10000;
+    }
+
+    return value;
+  }
+
+  async readAmbientTemperatureRaw() {
+    const low = await this.i2cSlave.read8(TAMBIENT_L);
+    const high = await this.i2cSlave.read8(TAMBIENT_H);
+
+    let value = (high << 8) | low;
+
+    // Convert unsigned 16-bit to signed 16-bit
+    if (value & 0x8000) {
+      value -= 0x10000;
+    }
+
+    return value;
+  }
+
+  async read() {
+    const objectRaw = await this.readObjectTemperatureRaw();
+    const ambientRaw = await this.readAmbientTemperatureRaw();
+
+    return {
+      objectTemperatureRaw: objectRaw,
+      ambientTemperatureRaw: ambientRaw,
+      ambientTemperature: ambientRaw / 100
+    };
+  }
+}
+
+export default STHS34PF80;

--- a/packages/sths34pf80/package.json
+++ b/packages/sths34pf80/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@chirimen/sths34pf80",
+  "description": "Driver for STHS34PF80 with WebI2C",
+  "version": "1.0.0",
+  "license": "MIT",
+  "type": "module",
+  "exports": "./index.js",
+  "peerDependencies": {
+    "node-web-i2c": "^1.1.51"
+  }
+}

--- a/packages/sths34pf80/package.json
+++ b/packages/sths34pf80/package.json
@@ -7,7 +7,8 @@
   "exports": "./index.js",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/KDDI-Technology/chirimen-drivers.git"
+    "url": "https://github.com/chirimen-oh/chirimen-drivers.git",
+    "directory": "packages/sths34pf80"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/sths34pf80/package.json
+++ b/packages/sths34pf80/package.json
@@ -5,6 +5,13 @@
   "license": "MIT",
   "type": "module",
   "exports": "./index.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/KDDI-Technology/chirimen-drivers.git"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
   "peerDependencies": {
     "node-web-i2c": "^1.1.51"
   }


### PR DESCRIPTION
## 概要

STMicroelectronics製 赤外線温度センサー STHS34PF80 のドライバを追加します。

- 測定対象温度と周囲温度を取得可能
- インターフェース: I2C
- デフォルトI2Cアドレス: 0x5A
- WHO_AM_IレジスタによるデバイスIDの確認に対応
- STATUS / FUNC_STATUSレジスタの読み取りに対応
- 16bitの温度データを取得し、符号付き値として処理
- WebI2C（node-web-i2c）に対応

## 動作確認

- Raspberry Pi + STHS34PF80実機にて動作確認済み
- `init()` によるセンサー初期化を確認済み
- `readWhoAmI()` により `0xD3` が取得できることを確認済み
- `read()` による対象温度および周囲温度の取得を確認済み
- 周囲温度は約26.4～26.6℃として取得できることを確認済み

## 追加ファイル

- `packages/sths34pf80/index.js`
- `packages/sths34pf80/package.json`